### PR TITLE
Add size command — directory size breakdown

### DIFF
--- a/src/commands/size.js
+++ b/src/commands/size.js
@@ -1,0 +1,60 @@
+const fs = require('fs');
+const path = require('path');
+
+const SKIP = new Set(['node_modules', '.git', 'dist', 'build']);
+
+function dirSize(dir) {
+  let total = 0;
+  const breakdown = {};
+
+  function walk(d) {
+    try {
+      for (const entry of fs.readdirSync(d, { withFileTypes: true })) {
+        if (SKIP.has(entry.name)) continue;
+        const full = path.join(d, entry.name);
+        if (entry.isDirectory()) {
+          walk(full);
+        } else if (entry.isFile()) {
+          const s = fs.statSync(full).size;
+          total += s;
+          const ext = path.extname(entry.name) || '(none)';
+          breakdown[ext] = (breakdown[ext] || 0) + s;
+        }
+      }
+    } catch { /* skip */ }
+  }
+
+  walk(dir);
+  return { total, breakdown };
+}
+
+function formatSize(bytes) {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function size(args) {
+  const target = args[0] || '.';
+  const dir = path.resolve(target);
+
+  if (!fs.existsSync(dir)) {
+    console.error(`  Directory not found: ${target}`);
+    process.exit(1);
+  }
+
+  const { total, breakdown } = dirSize(dir);
+
+  console.log(`\n  Directory Size: ${dir}\n`);
+  console.log(`  Total: ${formatSize(total)}\n`);
+  console.log(`  ${'Extension'.padEnd(12)} ${'Size'.padStart(10)}`);
+  console.log(`  ${'─'.repeat(12)} ${'─'.repeat(10)}`);
+
+  const sorted = Object.entries(breakdown).sort((a, b) => b[1] - a[1]);
+  for (const [ext, bytes] of sorted.slice(0, 15)) {
+    console.log(`  ${ext.padEnd(12)} ${formatSize(bytes).padStart(10)}`);
+  }
+  console.log('');
+}
+
+module.exports = size;

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,7 @@ const envInfo = require('./commands/env-info');
 const timer = require('./commands/timer');
 const ip = require('./commands/ip');
 const color = require('./commands/color');
+const size = require('./commands/size');
 
 const COMMANDS = {
   'git-stats': { fn: gitStats, desc: 'Show git contribution stats for current repo' },
@@ -30,6 +31,7 @@ const COMMANDS = {
   'timer':     { fn: timer,     desc: 'Countdown timer in terminal' },
   'ip':        { fn: ip,        desc: 'Show local and public IP addresses' },
   'color':     { fn: color,     desc: 'Preview a hex color with RGB/HSL info' },
+  'size':      { fn: size,      desc: 'Show directory size breakdown by file type' },
 };
 
 function showHelp() {


### PR DESCRIPTION
Adds `devkit size [dir]` to show directory size by file extension.