### PR TITLE
Add gitignore command — generate .gitignore templates

### DIFF
--- a/src/commands/gitignore.js
+++ b/src/commands/gitignore.js
@@ -1,0 +1,83 @@
+const fs = require('fs');
+const path = require('path');
+
+const TEMPLATES = {
+  node: `node_modules/
+dist/
+.env
+.env.local
+*.log
+coverage/
+`,
+  python: `__pycache__/
+*.pyc
+*.pyo
+.env
+venv/
+.venv/
+dist/
+*.egg-info/
+`,
+  java: `*.class
+*.jar
+target/
+.settings/
+.classpath
+.project
+`,
+  go: `bin/
+vendor/
+*.exe
+*.test
+`,
+  rust: `target/
+Cargo.lock
+`,
+  web: `.env
+node_modules/
+dist/
+build/
+.cache/
+`,
+  general: `.env
+.DS_Store
+Thumbs.db
+*.log
+*.tmp
+`,
+};
+
+function gitignore(args) {
+  if (args.length === 0) {
+    console.log('\n  Usage: devkit gitignore <language>');
+    console.log(`  Available: ${Object.keys(TEMPLATES).join(', ')}\n`);
+    return;
+  }
+
+  const lang = args[0].toLowerCase();
+  const template = TEMPLATES[lang];
+
+  if (!template) {
+    console.error(`  Unknown template: "${lang}". Available: ${Object.keys(TEMPLATES).join(', ')}`);
+    process.exit(1);
+  }
+
+  const write = args.includes('--write') || args.includes('-w');
+
+  if (write) {
+    const target = path.resolve('.gitignore');
+    if (fs.existsSync(target)) {
+      const existing = fs.readFileSync(target, 'utf-8');
+      fs.writeFileSync(target, existing + '\n' + template);
+      console.log(`\n  Appended ${lang} rules to .gitignore\n`);
+    } else {
+      fs.writeFileSync(target, template);
+      console.log(`\n  Created .gitignore with ${lang} rules\n`);
+    }
+  } else {
+    console.log(`\n  .gitignore template for ${lang}:\n`);
+    console.log(template);
+  }
+}
+
+module.exports = gitignore;

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,7 @@ const envInfo = require('./commands/env-info');
 const timer = require('./commands/timer');
 const ip = require('./commands/ip');
 const color = require('./commands/color');
+const gitignore = require('./commands/gitignore');
 const serve = require('./commands/serve');
 const size = require('./commands/size');
 
@@ -32,6 +33,7 @@ const COMMANDS = {
   'timer':     { fn: timer,     desc: 'Countdown timer in terminal' },
   'ip':        { fn: ip,        desc: 'Show local and public IP addresses' },
   'color':     { fn: color,     desc: 'Preview a hex color with RGB/HSL info' },
+  'gitignore':  { fn: gitignore,  desc: 'Generate .gitignore from language templates' },
   'serve':     { fn: serve,     desc: 'Simple local HTTP file server' },
   'size':      { fn: size,      desc: 'Show directory size breakdown by file type' },
 };


### PR DESCRIPTION
Adds `devkit gitignore <lang>` with templates for node, python, java, go, rust, web.